### PR TITLE
fixbug

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,1 @@
+nightly

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,7 +109,12 @@ impl Runtime {
         unsafe {
             let old: *mut ThreadContext = &mut self.threads[old_pos].ctx;
             let new: *const ThreadContext = &self.threads[pos].ctx;
+            
+            #[cfg(target_os = "macos")]
             asm!("call _switch", in("rdi") old, in("rsi") new, clobber_abi("C"));
+
+            #[cfg(not(target_os = "macos"))]
+            asm!("call switch", in ("rdi") old, in("rsi") new, clobber_abi("C"));
         }
         self.threads.len() > 0
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,7 +109,7 @@ impl Runtime {
         unsafe {
             let old: *mut ThreadContext = &mut self.threads[old_pos].ctx;
             let new: *const ThreadContext = &self.threads[pos].ctx;
-            asm!("call switch", in("rdi") old, in("rsi") new, clobber_abi("C"));
+            asm!("call _switch", in("rdi") old, in("rsi") new, clobber_abi("C"));
         }
         self.threads.len() > 0
     }


### PR DESCRIPTION
- The asm code `call switch` doesn't work in macOS, it should be `call _switch`
- Add rust-toochain
